### PR TITLE
Fixes a Bug with where portal 2 has to be installed in

### DIFF
--- a/gameinfo.txt
+++ b/gameinfo.txt
@@ -18,7 +18,7 @@
 		SearchPaths
 		{
 			Game				|gameinfo_path|.
-			Game				"|gameinfo_path|../../common/Portal 2/portal2"
+			Game				portal2
 		}
 	}
 }


### PR DESCRIPTION
the bug in question that this commit is fixing. a error where it cant find sound manifest. this is due to the path not being specified correctly if portal 2 is not installed in the same drive as steam itself since sourcemods can only appear if its in the steam/steamapps/sourcemods directory. this commit fixes the bug by making it in line 21 to for the right of Game be just portal2 instead of what it was previously.